### PR TITLE
Elasticsearch Plugin Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ Get a count of scheduled process executions by id within the past interval.
 
 ## log-exe
 Logs a given execution using fluent-cat.
+
+## fluent.conf
+The configuration to accept logs from the Boomi scripts, and send them to Elasticsearch.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A collection of utility scripts for [Dell Boomi](https://boomi.com/) using the A
 Requirements:
 * libxml2-utils
 * fluentd (log-* scripts)
+* fluent-cat plugin
+* fluentd elasticsearch plugin
+*** I reccomend using the ruby gem method to install fluentd and the plugins. I had issues getting fluent-cat to work right using TD-agent and other install methods.
 
 ## download-atom-log
 Download a given atom's container logs when provided a valid account and login.

--- a/fluent.conf
+++ b/fluent.conf
@@ -1,39 +1,59 @@
-#boomi process log config
+#!/bin/bash
 
-## built-in TCP input
-## $ echo <json> | fluent-cat <tag>
+# Copyright (C) 2018 Christopher Diaz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Utility script for logging process (execution) logs from Dell Boomi with Fluentd.
+
+
+#boomi  process log config
+
+#forward is listening for data on prot 24224 by default
 <source>
     @type forward
-    @id forward_input
+    @label @boomi
+    # Using the labels is not neccessary, but is very helpful if you need/want to add additional sources to this config.
 </source>
 
-## filter 
-<filter **.boomi>
-    @type parser
-    format /(?<name>[^ ]*)\t(?<time>[^ ]*)\t(?<level>[^ ]*)\t(?<message>[^\n]*)/
-    time_format %FT%TZ
-    key_name message 
-</filter>
 
-## match tag=debug.** and dump to console
-<match debug.**>
-    @type stdout
-    @id stdout_output
-</match>
+<label @boomi>
+    <filter **.boomi>
+        @type parser
+        key_name message
+        <parse>
+            @type regexp
+            # If your messages are not parsing right try altering the regex expression below. 
+            expression (?<name>.*[^20]) (?<time>20[^\\\.\n,]{18})\s*(?<level>[A-Z]*[^ \t]*)\s*(?<message>[^\n]*)
+            time_format %Y-%m-%dT%H:%M:%SZ
+        </parse>
+  </filter>
 
-#aws es config
-<match es.**>
-  @type "aws-elasticsearch-service"
-  type_name "boomi_process_log"
-  logstash_format true
-  include_tag_key true
-  tag_key "@log_name"
-  flush_interval 1s
+  <match debug.**>
+    @type elasticsearch
+    flush_interval 1s
+    # Enter domain name endpoint in host. Do not put http/https; Enter only http/https at scheme
+    scheme PUT_http_OR_https_HERE
+    host PUT_YOUR_ELASTICSEARCH_ENDPOINT_HERE
+    port 443
+    logstash_format true
+    logstash_prefix boomi
+    utc_index false
+    # Prevent reloading connections to AWS ES
+    reload_on_failure false
+    reload_connections false
+    type_name "boomi_process_log"
+  </match>
+</label>
 
-  <endpoint>
-    url <endpoint>
-    region us-west-2
-    access_key_id "<key>"
-    secret_access_key "<key>"
-  </endpoint>
-</match>

--- a/fluent.conf
+++ b/fluent.conf
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 # Copyright (C) 2018 Christopher Diaz
 #

--- a/fluent.conf
+++ b/fluent.conf
@@ -20,7 +20,7 @@
 
 #boomi  process log config
 
-#forward is listening for data on prot 24224 by default
+#forward is listening for data on port 24224 by default
 <source>
     @type forward
     @label @boomi

--- a/read-exe-feed.sh
+++ b/read-exe-feed.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2017 Christopher Towner
+# Copyright (C) 2018 Christopher Diaz
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Utility script for reading executions in RSS feed from Dell Boomi.
+# Utility script for logging process (execution) logs from Dell Boomi with Fluentd.
+
 
 usage() { echo "Usage: $0 -b <boomi_account> -u <user>:<pass> [-o <out_dir>] [-c <config>]" 1>&2; exit 1; }
 
@@ -43,6 +44,19 @@ fi
 #create log path if doesnt exists
 mkdir -p $path
 
+#check backfill.pos log for any previously errored downloads
+export backfill_pos=$path/backfill.pos
+if [ -f "${backfill_pos}" ]; then
+	while read backfill_exe_id; do
+		sed -i '1d' ${backfill_pos}
+		echo Backfill entry - $backfill_exe_id
+	    $(dirname "$0")/log-exe.sh -b ${acct} -u ${user} -e ${backfill_exe_id} -o ${path}
+		continue
+	done < ${backfill_pos}
+fi
+
+
+
 #download feed
 feed=$path/exe-feed.xml
 curl -s -o ${feed} https://platform.boomi.com/account/${acct}/feed/rss-2.0
@@ -59,18 +73,17 @@ exe_type='b3dc32d4-0dbe-43a7-9a82-9f15fde812ea'
 #get item count in feed and iterate
 item_count=$(xmllint --xpath 'count(/rss/channel/item)' ${feed})
 for (( i = 1; i <= $item_count; i++)); do
-    
     #check that item_type equal to exe_type
     item_type=$(xmllint --xpath 'string(/rss/channel/item['$i']/category[3])' ${feed})
     if [ "$item_type" != "$exe_type" ]; then
         #uncomment for debugging unhandled types
         #xmllint --xpath '/rss/channel/item['$i']' ${feed}; echo
         continue;
-    fi   
+    fi
 
     #get date and id from item
     exe_date=$(xmllint --xpath 'string(/rss/channel/item['$i']/pubDate)' ${feed})
-    exe_id=$(xmllint --xpath 'string(/rss/channel/item['$i']/guid)' ${feed} |sed 's/^.*executionId=//')
+	exe_id=$(xmllint --xpath 'string(/rss/channel/item['$i']/guid)' ${feed} |sed 's/^.*executionId=//')
 
     #if id last in pos (already processed), break from loop
     if [ "$exe_id" == "$last_exe_id" ]; then
@@ -78,13 +91,14 @@ for (( i = 1; i <= $item_count; i++)); do
     fi
 
     #if first in list, store temp to overwrite pos file
-    if [ -z "$first_exe_id" ]; then 
+    if [ -z "$first_exe_id" ]; then
         first_exe_id=${exe_id}
     fi
 
     #retrieve and log execution
     echo $exe_date - $exe_id
-    #$(dirname "$0")/log-exe.sh -b ${acct} -u ${user} -e ${exe_id} -o ${path}
+    $(dirname "$0")/log-exe.sh -b ${acct} -u ${user} -e ${exe_id} -o ${path}
+
 done
 
 #store first executed in pos for subsequent runs

--- a/read-exe-feed.sh
+++ b/read-exe-feed.sh
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Utility script for logging process (execution) logs from Dell Boomi with Fluentd.
+# Utility script for reading executions in RSS feed from Dell Boomi.
+
 
 
 usage() { echo "Usage: $0 -b <boomi_account> -u <user>:<pass> [-o <out_dir>] [-c <config>]" 1>&2; exit 1; }


### PR DESCRIPTION
Changes made to utilize the Elasticsearch plugin to simplify the process for sending logs to Elasticsearch. Changes also made to keep track of  feed download errors, and try again in subsequent runs.